### PR TITLE
set state to logon before return

### DIFF
--- a/session_state.go
+++ b/session_state.go
@@ -22,13 +22,13 @@ func (sm *stateMachine) Start(s *session) {
 }
 
 func (sm *stateMachine) Connect(session *session) {
+	sm.setState(session, logonState{})
+
 	// No special logon logic needed for FIX Acceptors.
 	if !session.InitiateLogon {
-		sm.setState(session, logonState{})
 		return
 	}
 
-	sm.setState(session, logonState{})
 	// Fire logon timeout event after the pre-configured delay period.
 	time.AfterFunc(session.LogonTimeout, func() { session.sessionEvent <- internal.LogonTimeout })
 


### PR DESCRIPTION
**问题：**
return 前不将 session 状态变更为 logon，当后续逻辑发生 error return 时，会让 session 一直处于 latent 状态，并且不会再次发起连接。
**解决方式：**
当 fix session 处于 latent 状态，并且准备发起 Connect 时，说明 TCP 连接已经建立，进行后续可能 error return 的逻辑之前，先将 session 状态变更为 logon，借由 logon 超时的回调，解决上述问题。并且此时 TCP 已经建立连接，变更为 logon 有其业务合理性。